### PR TITLE
fix inversed blend

### DIFF
--- a/lib/color.js
+++ b/lib/color.js
@@ -164,8 +164,8 @@ export default class Color {
 /* ========================================================================== */
 
 function blend(base, color, percentage, colorspace, isBlendingAlpha) {
-	const addition    = percentage / 100;
-	const subtraction = 1 - addition;
+	const subtraction    = percentage / 100;
+	const addition = 1 - subtraction;
 
 	if (colorspace === 'hsl') {
 		const { hue: h1, saturation: s1, lightness: l1, alpha: a1 } = color2hsl(base);
@@ -292,7 +292,7 @@ function color2hwb(color) {
 /* ========================================================================== */
 
 function contrast(color, percentage) {
-	// https://drafts.csswg.org/css-color/#contrast-adjuster
+	// https://www.w3.org/TR/2016/WD-css-color-4-20160705/#contrast-adjuster
 	const hwb = color2hwb(color);
 	const rgb = color2rgb(color);
 
@@ -320,7 +320,7 @@ function contrast(color, percentage) {
 }
 
 function colors2contrast(color1, color2) {
-	// https://drafts.csswg.org/css-color/#contrast-ratio
+	// https://www.w3.org/TR/2016/WD-css-color-4-20160705/#contrast-ratio
 	const rgb1 = color2rgb(color1);
 	const rgb2 = color2rgb(color2);
 	const l1 = rgb2luminance(rgb1.red, rgb1.green, rgb1.blue);
@@ -340,14 +340,14 @@ function rgb2luminance(red, green, blue) {
 		channel2luminance(blue)
 	];
 
-	// https://drafts.csswg.org/css-color/#luminance
+	// https://www.w3.org/TR/2016/WD-css-color-4-20160705/#luminance
 	const luminance = 0.2126 * redLuminance + 0.7152 * greenLuminance + 0.0722 * blueLuminance;
 
-	return luminance;
+	return Math.max(0, Math.min(luminance, 1));
 }
 
 function channel2luminance(value) {
-	// https://drafts.csswg.org/css-color/#luminance
+	// https://www.w3.org/TR/2016/WD-css-color-4-20160705/#luminance
 	const luminance = value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) /1.055, 2.4);
 
 	return luminance;

--- a/test/basic.colors.expect.css
+++ b/test/basic.colors.expect.css
@@ -82,15 +82,20 @@ test-blackness-whiteness-adjuster {
 
 test-tint-shade-adjuster {
 	color: rgb(100% 0% 0%);
-	color: rgb(100% 0% 0%);
-	color: rgb(100% 0% 0%);
 	color: rgb(100% 100% 100%);
 	color: rgb(0% 0% 0%);
-	color: rgb(100% 20% 20%);
-	color: rgb(80% 0% 0%);
+	color: rgb(100% 0% 0%);
+	color: rgb(100% 0% 0%);
+	color: rgb(100% 80% 80%);
+	color: rgb(20% 0% 0%);
 }
 
 test-blend-adjuster {
+	color: rgb(100% 0% 0%);
+	color: rgb(100% 35% 0%);
+	color: rgb(100% 75% 0%);
+	color: rgb(100% 100% 0%);
+
 	color: rgb(100% 50% 0%);
 	color: rgb(100% 50% 0%);
 	color: hsl(30 100% 50%);
@@ -98,15 +103,39 @@ test-blend-adjuster {
 }
 
 test-contrast-adjuster {
-	color: hwb(60 0% 100%);
-	color: hwb(60 0% 75%);
-	color: hwb(60 0% 50%);
-	color: hwb(60 0% 25%);
 	color: hwb(60 0% 0%);
+	color: hwb(60 0% 25%);
+	color: hwb(60 0% 50%);
+	color: hwb(60 0% 75%);
+	color: hwb(60 0% 100%);
+}
+
+contrast-on-white {
+	color: hwb(0 100% 0%);
+	color: hwb(0 75% 25%);
+	color: hwb(0 50% 50%);
+	color: hwb(0 25% 75%);
+	color: hwb(0 0% 100%);
+}
+
+contrast-on-grey {
+	color: hwb(0 49.8039215686% 50.1960784314%);
+	color: hwb(0 37.3529411765% 62.6470588235%);
+	color: hwb(0 24.9019607843% 75.0980392157%);
+	color: hwb(0 12.4509803922% 87.5490196078%);
+	color: hwb(0 0% 100%);
+}
+
+contrast-on-black {
+	color: hwb(0 0% 100%);
+	color: hwb(0 25% 75%);
+	color: hwb(0 50% 50%);
+	color: hwb(0 75% 25%);
+	color: hwb(0 100% 0%);
 }
 
 test-combination-adjuster {
-	color: rgb(70% 30.2012805122% 46.7647058824%);
+	color: rgb(70% 60% 80%);
 }
 
 test-sameness {
@@ -139,7 +168,7 @@ test-linear-gradient {
 }
 
 test-var-blend {
-	color: rgb(90% 0% 10%);
+	color: rgb(10% 0% 90%);
 }
 
 test-transparent {

--- a/test/basic.css
+++ b/test/basic.css
@@ -91,6 +91,11 @@ test-tint-shade-adjuster {
 }
 
 test-blend-adjuster {
+	color: color-mod(yellow blend(red 0%));
+	color: color-mod(yellow blend(red 35%));
+	color: color-mod(yellow blend(red 75%));
+	color: color-mod(yellow blend(red 100%));
+
 	color: color-mod(yellow blend(red 50%));
 	color: color-mod(yellow blend(red 50% rgb));
 	color: color-mod(yellow blend(red 50% hsl));
@@ -103,6 +108,30 @@ test-contrast-adjuster {
 	color: color-mod(yellow contrast(50%));
 	color: color-mod(yellow contrast(75%));
 	color: color-mod(yellow contrast(100%));
+}
+
+contrast-on-white {
+	color: color-mod(rgb(255, 255, 255) contrast(0%));
+	color: color-mod(rgb(255, 255, 255) contrast(25%));
+	color: color-mod(rgb(255, 255, 255) contrast(50%));
+	color: color-mod(rgb(255, 255, 255) contrast(75%));
+	color: color-mod(rgb(255, 255, 255) contrast(100%));
+}
+
+contrast-on-grey {
+	color: color-mod(rgb(127, 127, 127) contrast(0%));
+	color: color-mod(rgb(127, 127, 127) contrast(25%));
+	color: color-mod(rgb(127, 127, 127) contrast(50%));
+	color: color-mod(rgb(127, 127, 127) contrast(75%));
+	color: color-mod(rgb(127, 127, 127) contrast(100%));
+}
+
+contrast-on-black {
+	color: color-mod(rgb(0, 0, 0) contrast(0%));
+	color: color-mod(rgb(0, 0, 0) contrast(25%));
+	color: color-mod(rgb(0, 0, 0) contrast(50%));
+	color: color-mod(rgb(0, 0, 0) contrast(75%));
+	color: color-mod(rgb(0, 0, 0) contrast(100%));
 }
 
 test-combination-adjuster {

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -82,15 +82,20 @@ test-blackness-whiteness-adjuster {
 
 test-tint-shade-adjuster {
 	color: rgb(255, 0, 0);
-	color: rgb(255, 0, 0);
-	color: rgb(255, 0, 0);
 	color: rgb(255, 255, 255);
 	color: rgb(0, 0, 0);
-	color: rgb(255, 51, 51);
-	color: rgb(204, 0, 0);
+	color: rgb(255, 0, 0);
+	color: rgb(255, 0, 0);
+	color: rgb(255, 204, 204);
+	color: rgb(51, 0, 0);
 }
 
 test-blend-adjuster {
+	color: rgb(255, 0, 0);
+	color: rgb(255, 89, 0);
+	color: rgb(255, 191, 0);
+	color: rgb(255, 255, 0);
+
 	color: rgb(255, 128, 0);
 	color: rgb(255, 128, 0);
 	color: hsl(30, 100%, 50%);
@@ -98,15 +103,39 @@ test-blend-adjuster {
 }
 
 test-contrast-adjuster {
-	color: rgb(0, 0, 0);
-	color: rgb(64, 64, 0);
-	color: rgb(128, 128, 0);
-	color: rgb(191, 191, 0);
 	color: rgb(255, 255, 0);
+	color: rgb(191, 191, 0);
+	color: rgb(128, 128, 0);
+	color: rgb(64, 64, 0);
+	color: rgb(0, 0, 0);
+}
+
+contrast-on-white {
+	color: rgb(255, 255, 255);
+	color: rgb(191, 191, 191);
+	color: rgb(128, 128, 128);
+	color: rgb(64, 64, 64);
+	color: rgb(0, 0, 0);
+}
+
+contrast-on-grey {
+	color: rgb(127, 127, 127);
+	color: rgb(95, 95, 95);
+	color: rgb(64, 64, 64);
+	color: rgb(32, 32, 32);
+	color: rgb(0, 0, 0);
+}
+
+contrast-on-black {
+	color: rgb(0, 0, 0);
+	color: rgb(64, 64, 64);
+	color: rgb(128, 128, 128);
+	color: rgb(191, 191, 191);
+	color: rgb(255, 255, 255);
 }
 
 test-combination-adjuster {
-	color: rgb(179, 77, 119);
+	color: rgb(179, 153, 204);
 }
 
 test-sameness {
@@ -139,7 +168,7 @@ test-linear-gradient {
 }
 
 test-var-blend {
-	color: rgb(230, 0, 26);
+	color: rgb(26, 0, 230);
 }
 
 test-transparent {

--- a/test/import.expect.css
+++ b/test/import.expect.css
@@ -59,12 +59,12 @@ test-blackness-whiteness-adjuster {
 }
 
 test-tint-shade-adjuster {
-	color: rgb(0, 0, 255);
-	color: rgb(0, 0, 255);
 	color: rgb(255, 255, 255);
 	color: rgb(0, 0, 0);
-	color: rgb(51, 51, 255);
-	color: rgb(0, 0, 204);
+	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 255);
+	color: rgb(204, 204, 255);
+	color: rgb(0, 0, 51);
 }
 
 test-blend-adjuster {
@@ -75,15 +75,15 @@ test-blend-adjuster {
 }
 
 test-contrast-adjuster {
-	color: rgb(0, 0, 0);
-	color: rgb(0, 0, 64);
-	color: rgb(0, 0, 128);
-	color: rgb(0, 0, 191);
 	color: rgb(0, 0, 255);
+	color: rgb(0, 0, 191);
+	color: rgb(0, 0, 128);
+	color: rgb(0, 0, 64);
+	color: rgb(0, 0, 0);
 }
 
 test-combination-adjuster {
-	color: rgb(69, 50, 121);
+	color: rgb(179, 153, 204);
 }
 
 test-multiple-value-items {


### PR DESCRIPTION
see : https://github.com/csstools/postcss-color-mod-function/issues/13

spec : https://www.w3.org/TR/2016/WD-css-color-4-20160705/#contrast-adjuster

Core change : 

```diff
 function blend(base, color, percentage, colorspace, isBlendingAlpha) {
-       const addition    = percentage / 100;
-       const subtraction = 1 - addition;
+       const subtraction    = percentage / 100;
+       const addition = 1 - subtraction;
```

Spec notes on blend :

>Blend the minimum-contrast color and maximum-contrast color according to the specified `<percentage>`, as if `color(maximum-contrast color blend(minimum-contrast color <percentage> hwb))` were specified. Return the blended color.

Spec notes on percentage :

>The `<percentage>` specifies the desired similarity between the base color and the returned color. 0% will return the minimum-contrast color (the closest color to the base color that still contrasts sufficiently), while 100% will return the maximum-contrast color (white or black, whichever contrasts the base color more) Specifying a value less than 0% or greater than 100% is invalid and a syntax error. If omitted, the <percentage> defaults to 100%.


`0%` -> min contrast
`100%` -> max contrast


Spec notes on blending :

>''blend( `<color>` `<percentage>` [rgb | hsl | hwb]? )''
Mixes the base color with the given color to produce an intermediate color.

>To determine the resulting color, interpret the base color and the given color in the appropriate color space (RGB, HSL, or HWB). Linearly interpolate each of the channels of the colors according to the given `<percentage>`, where 0% produces the specified `<color>` and 100% produces the base color.

`0%` -> specified color in `blend` func
`100%` -> base color

------------

Combining `color(maximum-contrast color blend(minimum-contrast color <percentage> hwb))` and `blend`:

`0%` -> `minimum-contrast`
`100%` -> `maximum-contrast`

So the contrast function is correct.
The blend function however seems to have been incorrect.

------------

⚠️ **I am unsure if this is a change we want to make as it's a dead spec and a very breaking change.**